### PR TITLE
ci: follow latest PyPI publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,6 @@ jobs:
         run: python3 -m twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.10.1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
switch release workflow to pypa/gh-action-pypi publish@release/v1 so uploads stay compatible with newer metadata (e.g., Metadata-Version 2.4) and future action fixes.